### PR TITLE
Use DMA callback to end flush

### DIFF
--- a/examples/ILI9341_Demo/Core/Inc/ILI9341.h
+++ b/examples/ILI9341_Demo/Core/Inc/ILI9341.h
@@ -2,6 +2,7 @@
 #define ILI9341_H
 
 #include "stm32f4xx_hal.h"
+#include "lvgl.h"
 
 #define ILI9341_SPI       hspi1
 
@@ -30,6 +31,6 @@ void ILI9341_SetRotation(uint8_t m);
 //LVGL
 void ILI9341_SetWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
 void ILI9341_DrawBitmap(uint16_t w, uint16_t h, uint8_t *s);
-void ILI9341_DrawBitmapDMA(uint16_t w, uint16_t h, uint8_t *s);
+void ILI9341_DrawBitmapDMA(uint16_t w, uint16_t h, uint8_t *s, lv_display_t *disp);
 
 #endif

--- a/examples/ILI9341_Demo/Core/Src/ILI9341.c
+++ b/examples/ILI9341_Demo/Core/Src/ILI9341.c
@@ -1,7 +1,10 @@
 #include "ILI9341.h"
 #include "main.h"
+#include "lvgl.h"
 
 extern SPI_HandleTypeDef ILI9341_SPI;
+
+static lv_display_t *dma_display = NULL;
 
 #define CS_LOW()  HAL_GPIO_WritePin(ILI9341_CS_PORT, ILI9341_CS_PIN, GPIO_PIN_RESET)
 #define CS_HIGH() HAL_GPIO_WritePin(ILI9341_CS_PORT, ILI9341_CS_PIN, GPIO_PIN_SET)
@@ -197,11 +200,23 @@ void ILI9341_DrawBitmap(uint16_t w, uint16_t h, uint8_t *s)
     CS_HIGH();
 }
 
-void ILI9341_DrawBitmapDMA(uint16_t w, uint16_t h, uint8_t *s)
+void ILI9341_DrawBitmapDMA(uint16_t w, uint16_t h, uint8_t *s, lv_display_t *disp)
 {
     ILI9341_WriteCommand(0x2C); // Memory write
     DC_HIGH();
     CS_LOW();
+    dma_display = disp;
     HAL_SPI_Transmit_DMA(&ILI9341_SPI, s, w * h * 2);
+}
+
+void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+    if(hspi == &ILI9341_SPI) {
+        CS_HIGH();
+        if(dma_display) {
+            lv_display_flush_ready(dma_display);
+            dma_display = NULL;
+        }
+    }
 }
 

--- a/examples/ILI9341_Demo/Core/Src/LCDController.c
+++ b/examples/ILI9341_Demo/Core/Src/LCDController.c
@@ -136,8 +136,5 @@ static void disp_flush(lv_display_t * disp_drv, const lv_area_t * area, uint8_t 
     lv_color_t *color_p = (lv_color_t *) px_map;
 
 //    ILI9341_DrawBitmap(width, height, (uint8_t *) color_p);
-    ILI9341_DrawBitmapDMA(width, height, (uint8_t *) color_p);
-    /*IMPORTANT!!!
-     *Inform the graphics library that you are ready with the flushing*/
-    lv_display_flush_ready(disp_drv);
+    ILI9341_DrawBitmapDMA(width, height, (uint8_t *) color_p, disp_drv);
 }

--- a/stm32/Core/LCDController.c
+++ b/stm32/Core/LCDController.c
@@ -114,9 +114,6 @@ static void disp_flush(lv_display_t * disp_drv, const lv_area_t * area, uint8_t 
 
     lv_color_t *color_p = (lv_color_t *) px_map;
 
-    ILI9341_DrawBitmapDMA(width, height, (uint8_t *) color_p);
-    /*IMPORTANT!!!
-     *Inform the graphics library that you are ready with the flushing*/
-    lv_display_flush_ready(disp_drv);
+    ILI9341_DrawBitmapDMA(width, height, (uint8_t *) color_p, disp_drv);
 }
 

--- a/stm32/Drivers/ILI9341/ILI9341.c
+++ b/stm32/Drivers/ILI9341/ILI9341.c
@@ -4,8 +4,11 @@
  */
 #include "ILI9341.h"
 #include "main.h"
+#include "lvgl.h"
 
 extern SPI_HandleTypeDef ILI9341_SPI;
+
+static lv_display_t *dma_display = NULL;
 
 #define CS_LOW()  HAL_GPIO_WritePin(ILI9341_CS_PORT, ILI9341_CS_PIN, GPIO_PIN_RESET)
 #define CS_HIGH() HAL_GPIO_WritePin(ILI9341_CS_PORT, ILI9341_CS_PIN, GPIO_PIN_SET)
@@ -218,12 +221,24 @@ void ILI9341_DrawBitmap(uint16_t w, uint16_t h, uint8_t *s)
 }
 
 /** Write a bitmap using DMA */
-void ILI9341_DrawBitmapDMA(uint16_t w, uint16_t h, uint8_t *s)
+void ILI9341_DrawBitmapDMA(uint16_t w, uint16_t h, uint8_t *s, lv_display_t *disp)
 {
     ILI9341_WriteCommand(0x2C); // Memory write
     DC_HIGH();
     CS_LOW();
+    dma_display = disp;
     HAL_SPI_Transmit_DMA(&ILI9341_SPI, s, w * h * 2);
+}
+
+void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+    if(hspi == &ILI9341_SPI) {
+        CS_HIGH();
+        if(dma_display) {
+            lv_display_flush_ready(dma_display);
+            dma_display = NULL;
+        }
+    }
 }
 
 

--- a/stm32/Drivers/ILI9341/ILI9341.h
+++ b/stm32/Drivers/ILI9341/ILI9341.h
@@ -6,6 +6,7 @@
 #define ILI9341_H
 
 #include "stm32f4xx_hal.h"
+#include "lvgl.h"
 
 #define ILI9341_SPI       hspi1
 
@@ -32,7 +33,7 @@ void ILI9341_WriteData16(uint16_t data);
 //LVGL
 void ILI9341_SetWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);
 void ILI9341_DrawBitmap(uint16_t w, uint16_t h, uint8_t *s);
-void ILI9341_DrawBitmapDMA(uint16_t w, uint16_t h, uint8_t *s);
+void ILI9341_DrawBitmapDMA(uint16_t w, uint16_t h, uint8_t *s, lv_display_t *disp);
 
 #endif
 


### PR DESCRIPTION
## Summary
- store LVGL display pointer when starting a DMA transfer
- raise CS and call `lv_display_flush_ready` in the SPI completion callback
- wait for the callback in `disp_flush`

## Testing
- `cmake -S . -B build` *(fails: unrecognized options for ARM toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_687fe9f698dc8323a01a62ad5d6ddfe8